### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .phpunit.result.cache
 /examples
 run.bat
+**.1.php

--- a/README.md
+++ b/README.md
@@ -218,13 +218,13 @@ use WikiConnect\ParseWiki\ParserTags;
 $text = '<gallery>Images</gallery><ref>Ignore this</ref><gallery>More images</gallery>';
 
 $parser = new ParserTags($text, 'gallery');
-$tags = $parser->getTags();
+$tags   = $parser->getTags();
 
-$this->assertCount(2, $tags);
+echo 'Found ' . count($tags) . " gallery tags\n";
 foreach ($tags as $tag) {
-    $this->assertEquals('gallery', trim($tag->getName()));
-    echo 'Content: ' . $tag->getContent() . PHP_EOL;
-    echo 'Attributes: ' . $tag->getAttributes() . PHP_EOL;
+    echo 'Name:      ' . $tag->getName()      . PHP_EOL;
+    echo 'Content:   ' . $tag->getContent()   . PHP_EOL;
+    echo 'Attributes:' . json_encode($tag->getAttributes()) . PHP_EOL;
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,23 +21,25 @@ Perfect for handling wiki-formatted text in PHP projects.
 - `ParserTemplates`: Parses multiple templates.
 - `ParserTemplate`: Parses a single template.
 - `ParserInternalLinks`: Parses internal wiki links.
+- `ParserTags`: Parses html tags.
 - `ParserExternalLinks`: Parses external links.
 - `ParserCitations`: Parses citations and references.
 - `ParserCategories`: Parses categories from wiki text.
 - `DataModel` classes:
   - `Attribute`
-  - `Citation`
   - `ExternalLink`
   - `InternalLink`
   - `Parameters`
+  - `Tag`
   - `Template`
 - `tests/`: Contains PHPUnit test files:
   - `ParserCategoriesTest`
   - `ParserCitationsTest`
   - `ParserExternalLinksTest`
   - `ParserInternalLinksTest`
-  - `ParserTemplatesTest`
+  - `ParserTagsTest`
   - `ParserTemplateTest`
+  - `ParserTemplatesTest`
   - `DataModel` tests:
     - `AttributeTest`
     - `ParametersTest`
@@ -66,8 +68,8 @@ Perfect for handling wiki-formatted text in PHP projects.
 | **Citations>Attributes**   | ✅ Yes  | ✅ Yes    | ✅ Yes     |
 | **Internal Links**         | ✅ Yes  |     |      |
 | **External Links**         | ✅ Yes  |     |      |
-| **Categories**             | ✅ Yes  |      |       |
-| **HTML Tags**              |   |     |      |
+| **Categories**             | ✅ Yes  |      |     |
+| **HTML Tags**              | ✅ Yes  | ✅ Yes    | ✅ Yes     |
 | **Parser Functions**       |   |   |       |
 | **Tables**                 |   |      |       |
 | **Sections**               |   |      |       |
@@ -206,6 +208,25 @@ $categories = $parser->getCategories();
 foreach ($categories as $category) {
     echo 'Category: ' . $category . PHP_EOL;
 }
+```
+
+### Parsing HTML tags
+
+```php
+use WikiConnect\ParseWiki\ParserTags;
+
+$text = '<gallery>Images</gallery><ref>Ignore this</ref><gallery>More images</gallery>';
+
+$parser = new ParserTags($text, 'gallery');
+$tags = $parser->getTags();
+
+$this->assertCount(2, $tags);
+foreach ($tags as $tag) {
+    $this->assertEquals('gallery', trim($tag->getName()));
+    echo 'Content: ' . $tag->getContent() . PHP_EOL;
+    echo 'Attributes: ' . $tag->getAttributes() . PHP_EOL;
+}
+
 ```
 
 ---

--- a/src/DataModel/InternalLink.php
+++ b/src/DataModel/InternalLink.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WikiConnect\ParseWiki\DataModel;
 
 /**
@@ -61,9 +62,9 @@ class InternalLink
     public function toString(): string
     {
         if ($this->text == $this->target) {
-            return "[[".$this->target."]]";
+            return "[[" . $this->target . "]]";
         } else {
-            return "[[".$this->target."|".$this->text."]]";
+            return "[[" . $this->target . "|" . $this->text . "]]";
         }
     }
     public function __toString(): string
@@ -71,4 +72,3 @@ class InternalLink
         return $this->toString();
     }
 }
-

--- a/src/DataModel/Tag.php
+++ b/src/DataModel/Tag.php
@@ -5,13 +5,13 @@ namespace WikiConnect\ParseWiki\DataModel;
 use WikiConnect\ParseWiki\DataModel\Attribute;
 
 /**
- * Class Citation
+ * Class Tag
  *
- * Represents a citation in a wikitext document.
+ * Represents a tag in a wikitext document.
  *
  * @package WikiConnect\ParseWiki\DataModel
  */
-class Citation
+class Tag
 {
     /**
      * The name.
@@ -37,16 +37,17 @@ class Citation
 
     private bool $selfClosing = false;
     /**
-     * Citation constructor.
+     * Tag constructor.
      *
+     * @param string $tagname The name.
      * @param string $content The content.
      * @param string $attributes The attributes.
      * @param string $originalText The original, unprocessed text.
-     * @param bool $selfClosing Whether the citation is self-closing.
+     * @param bool $selfClosing Whether the tag is self-closing.
      */
-    public function __construct(string $content, string $attributes = "", string $originalText = "", bool $selfClosing = false)
+    public function __construct(string $tagname, string $content, string $attributes = "", string $originalText = "", bool $selfClosing = false)
     {
-        $this->tagname = "ref";
+        $this->tagname = $tagname;
         $this->content = $content;
         $this->attributes = $attributes;
         $this->originalText = $originalText;
@@ -126,7 +127,7 @@ class Citation
     /**
      * Convert the content to a string.
      *
-     * @return string The citation as a string.
+     * @return string The tag as a string.
      */
     public function toString(): string
     {

--- a/src/DataModel/Template.php
+++ b/src/DataModel/Template.php
@@ -43,7 +43,6 @@ class Template
      * @param array $parameters The parameters.
      * @param string $originalText The text.
      */
-
     public function __construct(string $name, array $parameters = [], string $originalText = "")
     {
         $this->name = $name;
@@ -108,7 +107,18 @@ class Template
         $this->name = $name;
         $this->nameStrip = trim(str_replace('_', ' ', $name));
     }
-
+    public function setParameter(string $key, string $value): void
+    {
+        $this->parameters->set($key, $value);
+    }
+    public function changeParameterName(string $old, string $new): void
+    {
+        $this->parameters->changeParametersNames([$old => $new]);
+    }
+    public function changeParametersNames(array $params_new): void
+    {
+        $this->parameters->changeParametersNames($params_new);
+    }
     /**
      * Convert the content to a string.
      *

--- a/src/ParserCitations.php
+++ b/src/ParserCitations.php
@@ -2,7 +2,8 @@
 
 namespace WikiConnect\ParseWiki;
 
-use WikiConnect\ParseWiki\DataModel\Citation;
+use WikiConnect\ParseWiki\DataModel\Tag;
+use WikiConnect\ParseWiki\ParserTags;
 
 /**
  * Class ParserCitations
@@ -19,14 +20,12 @@ class ParserCitations
     private string $text;
 
     /**
-     * @var Citation[] Array of extracted citations.
+     * @var Tag[] Array of extracted citations.
      */
     private array $citations;
 
     /**
      * ParserCitations constructor.
-     *
-     * Initializes the parser with the given text and starts the parsing process.
      *
      * @param string $text The text to parse.
      */
@@ -37,86 +36,20 @@ class ParserCitations
     }
 
     /**
-     * Find and extract citations from the given string.
-     *
-     * Uses a regular expression to match citations wrapped in <ref> tags.
-     *
-     * @param string $string The string to search for citations.
-     * @return array An array of matches found in the string.
-     */
-    private function find_sub_citations(string $string): array
-    {
-        $matches = [];
-
-        // full tags: <ref>...</ref>
-        preg_match_all(
-            '/<ref([^\/>]*)>(.+?)<\/ref>/is',
-            $string,
-            $standardMatches,
-            PREG_SET_ORDER
-        );
-
-        foreach ($standardMatches as $match) {
-            $matches[] = [
-                'original'    => $match[0],
-                'name'        => "ref",
-                'attributes'  => $match[1],
-                'content'     => $match[2],
-                'selfClosing' => false,
-            ];
-        }
-
-        // Self-closing tags like <ref ... />
-        preg_match_all(
-            '/<ref\s+([^>\/]*?)\s*\/>/is',
-            $string,
-            $selfClosingMatches,
-            PREG_SET_ORDER
-        );
-
-        foreach ($selfClosingMatches as $match) {
-            $matches[] = [
-                'original'    => $match[0],
-                'name'        => "ref",
-                'attributes'  => $match[1],
-                'content'     => '',
-                'selfClosing' => true,
-            ];
-        }
-
-        return $matches;
-    }
-
-    /**
-     * Parse the text for citations and store them.
-     *
-     * Uses find_sub_citations to identify citations and initializes
-     * Citation objects for each one found.
+     * Parse the text for <ref> tags using ParserTags and store them.
      *
      * @return void
      */
     public function parse(): void
     {
-        $text_citations = $this->find_sub_citations($this->text);
-        $this->citations = [];
-
-        foreach ($text_citations as $citationData) {
-            $_Citation = new Citation(
-                $citationData['content'],
-                $citationData['attributes'],
-                $citationData['original'],
-                $citationData['selfClosing']
-            );
-            $this->citations[] = $_Citation;
-        }
+        $tagParser = new ParserTags($this->text, 'ref'); // use ParserTags to extract <ref> tags
+        $this->citations = $tagParser->getTags();
     }
 
     /**
      * Get all citations found in the text.
      *
-     * Returns the array of Citation objects extracted from the text.
-     *
-     * @return Citation[] Array of Citation objects.
+     * @return Tag[] Array of Tag objects.
      */
     public function getCitations(): array
     {

--- a/src/ParserExternalLinks.php
+++ b/src/ParserExternalLinks.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace WikiConnect\ParseWiki;
+
 use WikiConnect\ParseWiki\DataModel\ExternalLink;
 
 /**
@@ -24,7 +26,8 @@ class ParserExternalLinks
      * ParserExternalLinks constructor.
      * @param string $text
      */
-    public function __construct(string $text) {
+    public function __construct(string $text)
+    {
         $this->text = $text;
         $this->parse();
     }

--- a/src/ParserInternalLinks.php
+++ b/src/ParserInternalLinks.php
@@ -64,5 +64,3 @@ class ParserInternalLinks
         return $this->targets;
     }
 }
-
-

--- a/src/ParserTags.php
+++ b/src/ParserTags.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace WikiConnect\ParseWiki;
+
+use WikiConnect\ParseWiki\DataModel\Tag;
+
+/**
+ * Class ParserTags
+ *
+ * Parses text to extract tags from wikitext.
+ *
+ * @package WikiConnect\ParseWiki
+ */
+class ParserTags
+{
+    /**
+     * @var string The text to parse for tags.
+     */
+    private string $text;
+    private string $tagname;
+
+    /**
+     * @var Tag[] Array of extracted tags.
+     */
+    private array $tags;
+
+    /**
+     * ParserTags constructor.
+     *
+     * Initializes the parser with the given text and starts the parsing process.
+     *
+     * @param string $text The text to parse.
+     * @param string $tagname The name of the tag to search for.
+     */
+    public function __construct(string $text, string $tagname = "")
+    {
+        $this->tagname = $tagname;
+        $this->text = $text;
+        $this->parse();
+    }
+
+    /**
+     * Find and extract tags from the given string.
+     *
+     * Uses a regular expression to match tags wrapped in <ref> tags.
+     *
+     * @param string $string The string to search for tags.
+     * @return array An array of matches found in the string.
+     */
+    private function find_sub_tags(string $string): array
+    {
+        $matches = [];
+
+        // full tags <ref>...</ref>
+        preg_match_all(
+            '/<(?<tag>[a-zA-Z0-9]+)(\s[^>]*)?>(.*?)<\/\k<tag>>/is',
+            $string,
+            $standardMatches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($standardMatches as $match) {
+            $matches[] = [
+                'original'    => $match[0],
+                'name'        => $match['tag'],
+                'attributes'  => $match[2],
+                'content'     => $match[3],
+                'selfClosing' => false,
+            ];
+        }
+
+        // Self-closing tags like <ref ... />
+        preg_match_all(
+            '/<(?<tag>[a-zA-Z0-9]+ *)(\s[^>]*)?\/>/is',
+            $string,
+            $selfClosingMatches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($selfClosingMatches as $match) {
+            $matches[] = [
+                'original'    => $match[0],
+                'name'        => $match['tag'],
+                'attributes'  => $match[2] ?? '',
+                'content'     => '',
+                'selfClosing' => true,
+            ];
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Parse the text for tags and store them.
+     *
+     * Uses find_sub_tags to identify tags and initializes
+     * Tag objects for each one found.
+     *
+     * @return void
+     */
+    public function parse(): void
+    {
+        $text_tags = $this->find_sub_tags($this->text);
+        $this->tags = [];
+
+        foreach ($text_tags as $citationData) {
+            if ($this->tagname != "" && trim($citationData['name']) != trim($this->tagname)) {
+                continue;
+            }
+            $_Citation = new Tag(
+                $citationData['name'],
+                $citationData['content'],
+                $citationData['attributes'],
+                $citationData['original'],
+                $citationData['selfClosing']
+            );
+            $this->tags[] = $_Citation;
+        }
+    }
+
+    /**
+     * Get all tags found in the text.
+     *
+     * If a name is given, only the tags with that name are returned.
+     *
+     * @param string|null $name The name of the tag to return.
+     *
+     * @return Tag[] An array of Tag objects.
+     */
+    public function getTags(?string $name = null): array
+    {
+        if (empty($name)) {
+            return $this->tags;
+        }
+
+        $outtags = [];
+        foreach ($this->tags as $tag) {
+            if ($tag->getName() == $name) {
+                $outtags[] = $tag;
+            }
+        }
+        return $outtags;
+    }
+}

--- a/src/ParserTemplates.php
+++ b/src/ParserTemplates.php
@@ -3,6 +3,7 @@
 namespace WikiConnect\ParseWiki;
 
 use WikiConnect\ParseWiki\DataModel\Template;
+use WikiConnect\ParseWiki\ParserTemplate;
 
 /**
  * Class ParserTemplates

--- a/tests/ParserCitationsTest.php
+++ b/tests/ParserCitationsTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use WikiConnect\ParseWiki\ParserCitations;
-use WikiConnect\ParseWiki\DataModel\Citation;
+use WikiConnect\ParseWiki\DataModel\Tag;
 use WikiConnect\ParseWiki\DataModel\Attribute;
 
 class ParserCitationsTest extends TestCase
@@ -14,7 +14,7 @@ class ParserCitationsTest extends TestCase
         $citations = $parser->getCitations();
 
         $this->assertCount(1, $citations);
-        $this->assertInstanceOf(Citation::class, $citations[0]);
+        $this->assertInstanceOf(Tag::class, $citations[0]);
         $this->assertEquals('Reference content', $citations[0]->getContent());
     }
 

--- a/tests/ParserTagsTest.php
+++ b/tests/ParserTagsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WikiConnect\ParseWiki\ParserTags;
+use WikiConnect\ParseWiki\DataModel\Tag;
+use WikiConnect\ParseWiki\DataModel\Attribute;
+
+class ParserTagsTest extends TestCase
+{
+    public function testSingleTag()
+    {
+        $text = '<gallery>Images go here</gallery>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $this->assertInstanceOf(Tag::class, $tags[0]);
+        $this->assertEquals('gallery', trim($tags[0]->getName()));
+        $this->assertEquals('Images go here', $tags[0]->getContent());
+    }
+
+    public function testMultipleDifferentTags()
+    {
+        $text = '<gallery>Images</gallery><math>E=mc^2</math><code>echo</code>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(3, $tags);
+        $this->assertEquals('gallery', trim($tags[0]->getName()));
+        $this->assertEquals('math', trim($tags[1]->getName()));
+        $this->assertEquals('code', trim($tags[2]->getName()));
+        $this->assertEquals('E=mc^2', $tags[1]->getContent());
+    }
+
+    public function testFilterByTagName()
+    {
+        $text = '<gallery>Images</gallery><ref>Ignore this</ref><gallery>More images</gallery>';
+        $parser = new ParserTags($text, 'gallery');
+        $tags = $parser->getTags();
+
+        $this->assertCount(2, $tags);
+        foreach ($tags as $tag) {
+            $this->assertEquals('gallery', trim($tag->getName()));
+        }
+    }
+
+    public function testSelfClosingSourceTag()
+    {
+        $text = '<source lang="bash" mode="console" />';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $tag = $tags[0];
+
+        $this->assertEquals('source', trim($tag->getName()));
+        $this->assertEquals('', $tag->getContent());
+        $this->assertTrue($tag->Attrs()->has('lang'));
+        $this->assertEquals('"bash"', $tag->Attrs()->get('lang'));
+    }
+
+    public function testTagWithUnquotedAttributes()
+    {
+        $text = '<timeline type=bar height=100>Graph</timeline>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $attrs = $tags[0]->Attrs();
+        $this->assertEquals('bar', $attrs->get('type'));
+        $this->assertEquals('100', $attrs->get('height'));
+    }
+
+    public function testMinimalRefTag()
+    {
+        $text = 'Example<ref>Ref content</ref>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $this->assertEquals('ref', trim($tags[0]->getName()));
+        $this->assertEquals('Ref content', $tags[0]->getContent());
+    }
+
+    public function testSelfClosingRefWithAttributes()
+    {
+        $text = '<ref name="x" group="g" />';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertCount(1, $tags);
+        $tag = $tags[0];
+
+        $this->assertEquals('ref', trim($tag->getName()));
+        $this->assertEquals('', $tag->getContent());
+        $this->assertEquals('"x"', $tag->Attrs()->get('name'));
+        $this->assertEquals('"g"', $tag->Attrs()->get('group'));
+    }
+
+    public function testGetOriginalText()
+    {
+        $text = '<math>E=mc^2</math>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertEquals('<math>E=mc^2</math>', $tags[0]->getOriginalText());
+    }
+
+    public function testToStringMatchesOriginal()
+    {
+        $text = '<ref name="r1">Some ref</ref>';
+        $parser = new ParserTags($text);
+        $tags = $parser->getTags();
+
+        $this->assertEquals($text, $tags[0]->toString());
+
+        $attrs = $tags[0]->Attrs();
+        $attrs->set('novalue2', 'new');
+        $this->assertEquals('new', $attrs->get('novalue2'));
+    }
+
+    public function testNoTags()
+    {
+        $text = 'Plain text without any tags.';
+        $parser = new ParserTags($text);
+        $this->assertCount(0, $parser->getTags());
+    }
+}


### PR DESCRIPTION
Renamed Citation to Tag and refactored ParserCitations to use a new generic ParserTags class for extracting tags from wikitext. Added ParserTags and corresponding tests to support parsing of arbitrary tags, not just <ref>. Updated tests and .gitignore accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a generic tag parsing capability, enabling extraction and handling of various tags (not just citations) from wikitext.
  * Added a new interface for accessing parsed tags, supporting filtering by tag name.

* **Refactor**
  * Replaced citation-specific logic with a more flexible tag-based approach throughout the application.
  * Updated class and method names to reflect the shift from citations to generic tags.

* **Tests**
  * Added comprehensive tests for tag parsing, covering multiple tag scenarios and attribute handling.
  * Updated existing tests to align with the new tag-based implementation.

* **Chores**
  * Updated ignore rules to exclude files ending with `.1.php`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->